### PR TITLE
Package parameter fix (issue #6)

### DIFF
--- a/hdl/fpu_fmac/LZA.sv
+++ b/hdl/fpu_fmac/LZA.sv
@@ -33,7 +33,10 @@
 import fpu_defs_fmac::*;
 
 module LZA
-#( parameter  C_WIDTH = 74)
+#(
+   parameter  C_WIDTH         = 74,
+   parameter  C_LEADONE_WIDTH = fpu_defs_fmac::C_LEADONE_WIDTH
+)
   (
    input  logic [C_WIDTH-1:0]                A_DI,
    input  logic [C_WIDTH-1:0]                B_DI,

--- a/hdl/fpu_fmac/LZA.sv
+++ b/hdl/fpu_fmac/LZA.sv
@@ -28,6 +28,11 @@
 // Revision:        26/06/2017                                                //
 // Revision:        04/09/2017                                                //
 //                  Added No_one_SI as an output by Lei Li                    //
+// Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs_fmac::*;

--- a/hdl/fpu_fmac/LZA.sv
+++ b/hdl/fpu_fmac/LZA.sv
@@ -11,9 +11,9 @@
 // Company:        IIS @ ETHZ - Federal Institute of Technology               //
 //                                                                            //
 // Engineers:      Lei Li  lile@iis.ee.ethz.ch                                //
-//		                                                              //
-// Additional contributions by:                                               //
 //                                                                            //
+// Additional contributions by:                                               //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    01/12/2016                                                 //

--- a/hdl/fpu_fmac/adders.sv
+++ b/hdl/fpu_fmac/adders.sv
@@ -28,6 +28,11 @@
 // Revision:       03/04/2018                                                 //
 //                 Fixed Torbjørn Viem Ness bugs  and Sticky bit              //
 //                                                                            //
+// Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs_fmac::*;

--- a/hdl/fpu_fmac/adders.sv
+++ b/hdl/fpu_fmac/adders.sv
@@ -11,9 +11,9 @@
 // Company:        IIS @ ETHZ - Federal Institute of Technology               //
 //                                                                            //
 // Engineers:      Lei Li  lile@iis.ee.ethz.ch                                //
-//		                                                                        //
-// Additional contributions by:                                               //
 //                                                                            //
+// Additional contributions by:                                               //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    01/12/2016                                                 // 

--- a/hdl/fpu_fmac/adders.sv
+++ b/hdl/fpu_fmac/adders.sv
@@ -33,6 +33,10 @@
 import fpu_defs_fmac::*;
 
 module adders
+#(
+   parameter C_MANT = fpu_defs_fmac::C_MANT,
+   parameter C_EXP  = fpu_defs_fmac::C_EXP
+)
   (
 
    input  logic [2*C_MANT+1:0]             AL_DI,  // The sum of the former unit  

--- a/hdl/fpu_fmac/aligner.sv
+++ b/hdl/fpu_fmac/aligner.sv
@@ -34,6 +34,11 @@
 import fpu_defs_fmac::*;
 
 module aligner
+#(
+   parameter C_EXP  = fpu_defs_fmac::C_EXP,
+   parameter C_MANT = fpu_defs_fmac::C_MANT,
+   parameter C_BIAS = fpu_defs_fmac::C_BIAS
+)
   (//Inputs
    input logic [C_EXP-1:0]                         Exp_a_DI,
    input logic [C_EXP-1:0]                         Exp_b_DI,

--- a/hdl/fpu_fmac/aligner.sv
+++ b/hdl/fpu_fmac/aligner.sv
@@ -11,9 +11,9 @@
 // Company:        IIS @ ETHZ - Federal Institute of Technology               //
 //                                                                            //
 // Engineers:      Lei Li  lile@iis.ee.ethz.ch                                //
-//		                                                              //
-// Additional contributions by:                                               //
 //                                                                            //
+// Additional contributions by:                                               //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    01/12/2016                                                 //

--- a/hdl/fpu_fmac/aligner.sv
+++ b/hdl/fpu_fmac/aligner.sv
@@ -29,6 +29,11 @@
 //                 Fixed Torbjørn Viem Ness bugs  and Sticky bit              //
 // Revision:       19/04/2018                                                 //
 //                 Sticky bit for substraction                                //
+// Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs_fmac::*;

--- a/hdl/fpu_fmac/fmac.sv
+++ b/hdl/fpu_fmac/fmac.sv
@@ -13,6 +13,7 @@
 // Engineers:      Lei Li -- lile@iis.ee.ethz.ch                              //
 //                                                                            //
 // Additional contributions by:                                               //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 //                                                                            //

--- a/hdl/fpu_fmac/fmac.sv
+++ b/hdl/fpu_fmac/fmac.sv
@@ -30,6 +30,11 @@
 //                 No_one_S was added  by Lei Li                              //
 // Revision:       03/04/2018                                                 //
 //                 Fixed Torbjørn Viem Ness bugs  and Sticky bit              //
+// Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs_fmac::*;

--- a/hdl/fpu_fmac/fmac.sv
+++ b/hdl/fpu_fmac/fmac.sv
@@ -35,6 +35,13 @@
 import fpu_defs_fmac::*;
 
 module fmac
+#(
+   parameter C_EXP           = fpu_defs_fmac::C_EXP,
+   parameter C_MANT          = fpu_defs_fmac::C_MANT,
+   parameter C_OP            = fpu_defs_fmac::C_OP,
+   parameter C_RM            = fpu_defs_fmac::C_RM,
+   parameter C_LEADONE_WIDTH = fpu_defs_fmac::C_LEADONE_WIDTH
+)
 (
    //Inputs
    input logic [C_OP-1:0]   Operand_a_DI,

--- a/hdl/fpu_fmac/fpu_norm_fmac.sv
+++ b/hdl/fpu_fmac/fpu_norm_fmac.sv
@@ -33,7 +33,17 @@
 import fpu_defs_fmac::*;
 
 module fpu_norm_fmac
-
+#(
+   parameter C_LEADONE_WIDTH = fpu_defs_fmac::C_LEADONE_WIDTH,
+   parameter C_EXP           = fpu_defs_fmac::C_EXP,
+   parameter C_MANT          = fpu_defs_fmac::C_MANT,
+   parameter C_RM            = fpu_defs_fmac::C_RM,
+   parameter C_RM_NEAREST    = fpu_defs_fmac::C_RM_NEAREST,
+   parameter C_RM_TRUNC      = fpu_defs_fmac::C_RM_TRUNC,
+   parameter C_RM_PLUSINF    = fpu_defs_fmac::C_RM_PLUSINF,
+   parameter C_RM_MINUSINF   = fpu_defs_fmac::C_RM_MINUSINF,
+   parameter C_MANT_NAN      = fpu_defs_fmac::C_MANT_NAN
+)
   (//Inputs
    input logic [3*C_MANT+4:0]              Mant_in_DI,
    input logic signed [C_EXP+1:0]          Exp_in_DI,

--- a/hdl/fpu_fmac/fpu_norm_fmac.sv
+++ b/hdl/fpu_fmac/fpu_norm_fmac.sv
@@ -28,6 +28,11 @@
 // Revision:        28/06/2017                                                //
 // Revision:        04/09/2017                                                //
 //                  Fix a bug in normalization by Lei Li                      //
+// Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs_fmac::*;

--- a/hdl/fpu_fmac/fpu_norm_fmac.sv
+++ b/hdl/fpu_fmac/fpu_norm_fmac.sv
@@ -11,9 +11,9 @@
 // Company:        IIS @ ETHZ - Federal Institute of Technology               //
 //                                                                            //
 // Engineers:      Lei Li  lile@iis.ee.ethz.ch                                //
-//		                                                              //
-// Additional contributions by:                                               //
 //                                                                            //
+// Additional contributions by:                                               //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    01/12/2016                                                 //
@@ -31,7 +31,7 @@
 // Revision:                                                                  //
 //                15/05/2018                                                  //
 //                Pass package parameters as default args instead of using    //
-//                them directly, improves compatibility with tools like       //  
+//                them directly, improves compatibility with tools like       //
 //                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/hdl/fpu_fmac/pp_generation.sv
+++ b/hdl/fpu_fmac/pp_generation.sv
@@ -27,6 +27,11 @@
 //                                                                            //
 //                                                                            //
 // Revision:        21/06/2017                                                //
+// Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs_fmac::*;

--- a/hdl/fpu_fmac/pp_generation.sv
+++ b/hdl/fpu_fmac/pp_generation.sv
@@ -32,6 +32,9 @@
 import fpu_defs_fmac::*;
 
 module pp_generation
+#(
+   parameter C_MANT = fpu_defs_fmac::C_MANT
+)
   (//Inputs
    input logic [C_MANT:0]                            Mant_a_DI,
    input logic [C_MANT:0]                            Mant_b_DI,

--- a/hdl/fpu_fmac/pp_generation.sv
+++ b/hdl/fpu_fmac/pp_generation.sv
@@ -11,9 +11,9 @@
 // Company:        IIS @ ETHZ - Federal Institute of Technology               //
 //                                                                            //
 // Engineers:      Lei Li  lile@iis.ee.ethz.ch                                //
-//		                                                              //
-// Additional contributions by:                                               //
 //                                                                            //
+// Additional contributions by:                                               //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    01/12/2016                                                 //

--- a/hdl/fpu_fmac/preprocess_fmac.sv
+++ b/hdl/fpu_fmac/preprocess_fmac.sv
@@ -11,9 +11,9 @@
 // Company:        IIS @ ETHZ - Federal Institute of Technology               //
 //                                                                            //
 // Engineers:      Lei Li  lile@iis.ee.ethz.ch                                //
-//		                                                              //
-// Additional contributions by:                                               //
 //                                                                            //
+// Additional contributions by:                                               //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    01/12/2016                                                 // 

--- a/hdl/fpu_fmac/preprocess_fmac.sv
+++ b/hdl/fpu_fmac/preprocess_fmac.sv
@@ -33,6 +33,14 @@
 import fpu_defs_fmac::*;
 
 module preprocess_fmac
+#(
+   parameter C_EXP_ONE   = fpu_defs_fmac::C_EXP_ONE,
+   parameter C_EXP_INF   = fpu_defs_fmac::C_EXP_INF,
+   parameter C_MANT_ZERO = fpu_defs_fmac::C_MANT_ZERO,
+   parameter C_MANT      = fpu_defs_fmac::C_MANT,
+   parameter C_EXP       = fpu_defs_fmac::C_EXP,
+   parameter C_OP        = fpu_defs_fmac::C_OP
+)
   (//Inputs
    input logic [C_OP-1:0]          Operand_a_DI,
    input logic [C_OP-1:0]          Operand_b_DI,

--- a/hdl/fpu_fmac/preprocess_fmac.sv
+++ b/hdl/fpu_fmac/preprocess_fmac.sv
@@ -28,6 +28,11 @@
 //                                                                            //
 // Revision:        13/09/2017                                                //
 //                  Added some signals for normalization by Lei Li            //
+// Revision:                                                                  //
+//                  15/05/2018                                                //
+//                  Pass package parameters as default args instead of using  //
+//                  them directly, improves compatibility with tools like     //  
+//                  Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs_fmac::*;

--- a/hdl/fpu_fmac/wallace.sv
+++ b/hdl/fpu_fmac/wallace.sv
@@ -32,6 +32,9 @@
 import fpu_defs_fmac::*;
 
 module wallace
+#(
+   parameter C_MANT = fpu_defs_fmac::C_MANT
+)
   (
    input logic [12:0] [2*C_MANT+2:0]                Pp_index_DI,
    output logic [2*C_MANT+2:0]                      Pp_sum_DO,

--- a/hdl/fpu_fmac/wallace.sv
+++ b/hdl/fpu_fmac/wallace.sv
@@ -27,6 +27,11 @@
 //                                                                            //
 //                                                                            //
 // Revision:       23/06/2017                                                 //
+// Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs_fmac::*;

--- a/hdl/fpu_fmac/wallace.sv
+++ b/hdl/fpu_fmac/wallace.sv
@@ -11,9 +11,9 @@
 // Company:        IIS @ ETHZ - Federal Institute of Technology               //
 //                                                                            //
 // Engineers:      Lei Li  lile@iis.ee.ethz.ch                                //
-//		                                                              //
-// Additional contributions by:                                               //
 //                                                                            //
+// Additional contributions by:                                               //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    01/12/2016                                                 //

--- a/hdl/fpu_v0.1/fpexc.sv
+++ b/hdl/fpu_v0.1/fpexc.sv
@@ -15,6 +15,7 @@
 //                                                                            //
 // Additional contributions by:                                               //
 //                  Lei Li       --lile@iis.ee.ethz.ch                        //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    06/10/2014                                                 //

--- a/hdl/fpu_v0.1/fpexc.sv
+++ b/hdl/fpu_v0.1/fpexc.sv
@@ -30,6 +30,11 @@
 // Revision:                                                                  //
 //                12/09/2012                                                  //
 //                Fixed some wrong flags by Lei Li                            //
+// Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs::*;

--- a/hdl/fpu_v0.1/fpexc.sv
+++ b/hdl/fpu_v0.1/fpexc.sv
@@ -35,6 +35,22 @@
 import fpu_defs::*;
 
 module fpexc
+#(
+   parameter C_MANT_ZERO   = fpu_defs::C_MANT_ZERO,
+   parameter C_EXP_ZERO    = fpu_defs::C_EXP_ZERO,
+   parameter C_EXP_INF     = fpu_defs::C_EXP_INF,
+
+   parameter C_EXP         = fpu_defs::C_EXP,
+   parameter C_MANT        = fpu_defs::C_MANT,
+
+   parameter C_CMD         = fpu_defs::C_CMD,
+
+   parameter C_FPU_ADD_CMD = fpu_defs::C_FPU_ADD_CMD,
+   parameter C_FPU_SUB_CMD = fpu_defs::C_FPU_SUB_CMD,
+   parameter C_FPU_MUL_CMD = fpu_defs::C_FPU_MUL_CMD,
+   parameter C_FPU_I2F_CMD = fpu_defs::C_FPU_I2F_CMD,
+   parameter C_FPU_F2I_CMD = fpu_defs::C_FPU_F2I_CMD
+)
   (//Input
    input logic [C_MANT:0]   Mant_a_DI,
    input logic [C_MANT:0]   Mant_b_DI,

--- a/hdl/fpu_v0.1/fpu.sv
+++ b/hdl/fpu_v0.1/fpu.sv
@@ -73,7 +73,6 @@ module fpu
    logic [C_RM-1:0]        RM_S;
    logic [C_CMD-1:0]       OP_S;
 
-   logic                   Stall_S;
 
 
    //Input register
@@ -123,7 +122,6 @@ module fpu
       .Operand_b_DI  ( Operand_b_D  ),
       .RM_SI         ( RM_S         ),
       .OP_SI         ( OP_S         ),
-      .Stall_SI      ( Stall_SI     ),
 
       .Result_DO     ( Result_D     ),
 

--- a/hdl/fpu_v0.1/fpu.sv
+++ b/hdl/fpu_v0.1/fpu.sv
@@ -28,6 +28,10 @@
 //                                                                            //
 //                                                                            //
 // Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs::*;

--- a/hdl/fpu_v0.1/fpu.sv
+++ b/hdl/fpu_v0.1/fpu.sv
@@ -14,7 +14,7 @@
 //                 Thomas Gautschi -- gauthoma@student.ethz.ch                //
 //                                                                            //
 // Additional contributions by:                                               //
-//                                                                            //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    26/10/2014                                                 //

--- a/hdl/fpu_v0.1/fpu.sv
+++ b/hdl/fpu_v0.1/fpu.sv
@@ -12,7 +12,7 @@
 //                                                                            //
 // Engineers:      Lukas Mueller -- lukasmue@student.ethz.ch                  //
 //                 Thomas Gautschi -- gauthoma@student.ethz.ch                //
-//		                                                                        //
+//                                                                            //
 // Additional contributions by:                                               //
 //                                                                            //
 //                                                                            //
@@ -33,6 +33,11 @@
 import fpu_defs::*;
 
 module fpu
+#(
+   parameter C_CMD = fpu_defs::C_CMD,
+   parameter C_RM  = fpu_defs::C_RM,
+   parameter C_OP  = fpu_defs::C_OP
+)
   (
    //Clock and reset
    input logic 	           Clk_CI,
@@ -76,7 +81,7 @@ module fpu
              Operand_a_D <= '0;
              Operand_b_D <= '0;
              RM_S        <= '0;
-	           OP_S        <= '0;
+             OP_S        <= '0;
           end
         else
           begin
@@ -85,7 +90,7 @@ module fpu
                   Operand_a_D <= Operand_a_DI;
                   Operand_b_D <= Operand_b_DI;
                   RM_S        <= RM_SI;
-	                OP_S        <= OP_SI;
+                  OP_S        <= OP_SI;
                end
           end
      end

--- a/hdl/fpu_v0.1/fpu_add.sv
+++ b/hdl/fpu_v0.1/fpu_add.sv
@@ -27,6 +27,10 @@
 //                 for Normalizer/Rounding stage                              //
 //                                                                            //
 // Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs::*;

--- a/hdl/fpu_v0.1/fpu_add.sv
+++ b/hdl/fpu_v0.1/fpu_add.sv
@@ -32,6 +32,16 @@
 import fpu_defs::*;
 
 module fpu_add
+#(
+   parameter C_EXP_PRENORM  = fpu_defs::C_EXP_PRENORM,
+   parameter C_MANT_PRENORM = fpu_defs::C_MANT_PRENORM,
+   parameter C_MANT_SHIFTED = fpu_defs::C_MANT_SHIFTED,
+   parameter C_MANT_SHIFTIN = fpu_defs::C_MANT_SHIFTIN,
+   parameter C_MANT_ADDOUT  = fpu_defs::C_MANT_ADDOUT,
+   parameter C_MANT_ADDIN   = fpu_defs::C_MANT_ADDIN,
+   parameter C_EXP          = fpu_defs::C_EXP,
+   parameter C_MANT         = fpu_defs::C_MANT
+)
   (//Input
    input logic               Sign_a_DI,
    input logic               Sign_b_DI,

--- a/hdl/fpu_v0.1/fpu_add.sv
+++ b/hdl/fpu_v0.1/fpu_add.sv
@@ -13,7 +13,7 @@
 // Engineers:      Lukas Mueller -- lukasmue@student.ethz.ch                  //
 //                                                                            //
 // Additional contributions by:                                               //
-//                                                                            //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    06/10/2014                                                 //

--- a/hdl/fpu_v0.1/fpu_core.sv
+++ b/hdl/fpu_v0.1/fpu_core.sv
@@ -39,6 +39,26 @@
 import fpu_defs::*;
 
 module fpu_core
+#(
+   parameter C_EXP_PRENORM  = fpu_defs::C_EXP_PRENORM,
+   parameter C_MANT_PRENORM = fpu_defs::C_MANT_PRENORM,
+   parameter C_EXP_ZERO     = fpu_defs::C_EXP_ZERO,
+   parameter C_EXP_INF      = fpu_defs::C_EXP_INF,
+   parameter C_MANT_ZERO    = fpu_defs::C_MANT_ZERO,
+   parameter F_QNAN         = fpu_defs::F_QNAN,
+
+   parameter C_OP           = fpu_defs::C_OP,
+   parameter C_CMD          = fpu_defs::C_CMD,
+   parameter C_RM           = fpu_defs::C_RM,
+   parameter C_EXP          = fpu_defs::C_EXP,
+   parameter C_MANT         = fpu_defs::C_MANT,
+
+   parameter C_FPU_ADD_CMD  = fpu_defs::C_FPU_ADD_CMD,
+   parameter C_FPU_SUB_CMD  = fpu_defs::C_FPU_SUB_CMD,
+   parameter C_FPU_MUL_CMD  = fpu_defs::C_FPU_MUL_CMD,
+   parameter C_FPU_I2F_CMD  = fpu_defs::C_FPU_I2F_CMD,
+   parameter C_FPU_F2I_CMD  = fpu_defs::C_FPU_F2I_CMD
+)
   (
    //Clock and reset
    input logic 	           Clk_CI,

--- a/hdl/fpu_v0.1/fpu_core.sv
+++ b/hdl/fpu_v0.1/fpu_core.sv
@@ -34,6 +34,11 @@
 //                15/05/2018                                                  //
 //                Fixed bug with the sign being ignored in multiplications    //
 //                where the result is zero (GitHub #5) - Torbjørn Viem Ness   //
+// Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs::*;

--- a/hdl/fpu_v0.1/fpu_core.sv
+++ b/hdl/fpu_v0.1/fpu_core.sv
@@ -12,10 +12,10 @@
 //                                                                            //
 // Engineers:      Lukas Mueller -- lukasmue@student.ethz.ch                  //
 //                 Thomas Gautschi -- gauthoma@student.ethz.ch                //
-//		                                                                        //
+//                                                                            //
 // Additional contributions by:                                               //
 //                  lile  -- lile@iis.ee.ethz.ch                              //
-//                                                                            //
+//                  Torbjørn Viem Ness -- torbjovn@stud.ntnu.no               //
 //                                                                            //
 // Create Date:    26/10/2014                                                 //
 // Design Name:    FPU                                                        //
@@ -30,6 +30,10 @@
 // Revision:                                                                  //
 //                12/09/2017                                                  //
 //                Updated the special cases   by Lei Li                       //
+// Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Fixed bug with the sign being ignored in multiplications    //
+//                where the result is zero (GitHub #5) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs::*;
@@ -338,7 +342,7 @@ module fpu_core
    // Output Assignments
    /////////////////////////////////////////////////////////////////////////////
 
-   assign Sign_res_D = Zero_S ? 1'b0 : Sign_norm_D;
+   assign Sign_res_D = (Zero_S && (OP_SP != C_FPU_MUL_CMD)) ? 1'b0 : Sign_norm_D;
    always_comb
      begin
         Exp_res_D = Exp_norm_D;

--- a/hdl/fpu_v0.1/fpu_ftoi.sv
+++ b/hdl/fpu_v0.1/fpu_ftoi.sv
@@ -27,6 +27,10 @@
 //                                                                            //
 //                                                                            //
 // Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs::*;

--- a/hdl/fpu_v0.1/fpu_ftoi.sv
+++ b/hdl/fpu_v0.1/fpu_ftoi.sv
@@ -32,6 +32,15 @@
 import fpu_defs::*;
 
 module fpu_ftoi
+#(
+   parameter C_EXP_SHIFT  = fpu_defs::C_EXP_SHIFT,
+   parameter C_SHIFT_BIAS = fpu_defs::C_SHIFT_BIAS,
+   parameter C_OP         = fpu_defs::C_OP,
+   parameter C_EXP        = fpu_defs::C_EXP,
+   parameter C_MANT       = fpu_defs::C_MANT,
+   parameter C_INF        = fpu_defs::C_INF,
+   parameter C_MINF       = fpu_defs::C_MINF
+)
   (//Input
    input logic             Sign_a_DI,
    input logic [C_EXP-1:0] Exp_a_DI,

--- a/hdl/fpu_v0.1/fpu_ftoi.sv
+++ b/hdl/fpu_v0.1/fpu_ftoi.sv
@@ -13,7 +13,7 @@
 // Engineers:      Thomas Gautschi -- gauthoma@student.ethz.ch                //
 //                                                                            //
 // Additional contributions by:                                               //
-//                                                                            //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    29/10/2014                                                 //

--- a/hdl/fpu_v0.1/fpu_itof.sv
+++ b/hdl/fpu_v0.1/fpu_itof.sv
@@ -27,6 +27,10 @@
 //                                                                            //
 //                                                                            //
 // Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs::*;

--- a/hdl/fpu_v0.1/fpu_itof.sv
+++ b/hdl/fpu_v0.1/fpu_itof.sv
@@ -32,6 +32,14 @@
 import fpu_defs::*;
 
 module fpu_itof
+#(
+   parameter C_EXP_PRENORM  = fpu_defs::C_EXP_PRENORM,
+   parameter C_MANT_PRENORM = fpu_defs::C_MANT_PRENORM,
+   parameter C_MANT_INT     = fpu_defs::C_MANT_INT,
+   parameter C_PADMANT      = fpu_defs::C_PADMANT,
+   parameter C_UNKNOWN      = fpu_defs::C_UNKNOWN,
+   parameter C_OP           = fpu_defs::C_OP
+)
   (//Input
    input logic [C_OP-1:0]                   Operand_a_DI,
 

--- a/hdl/fpu_v0.1/fpu_itof.sv
+++ b/hdl/fpu_v0.1/fpu_itof.sv
@@ -13,7 +13,7 @@
 // Engineers:      Thomas Gautschi -- gauthoma@student.ethz.ch                //
 //                                                                            //
 // Additional contributions by:                                               //
-//                                                                            //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    31/10/2014                                                 //

--- a/hdl/fpu_v0.1/fpu_mult.sv
+++ b/hdl/fpu_v0.1/fpu_mult.sv
@@ -27,6 +27,10 @@
 //                 Normalizer/Rounding stage                                  //
 //                                                                            //
 // Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs::*;

--- a/hdl/fpu_v0.1/fpu_mult.sv
+++ b/hdl/fpu_v0.1/fpu_mult.sv
@@ -13,7 +13,7 @@
 // Engineers:      Thomas Gautschi -- gauthoma@student.ethz.ch                //
 //                                                                            //
 // Additional contributions by:                                               //
-//                                                                            //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    06/10/2014                                                 //

--- a/hdl/fpu_v0.1/fpu_mult.sv
+++ b/hdl/fpu_v0.1/fpu_mult.sv
@@ -32,6 +32,13 @@
 import fpu_defs::*;
 
 module fpu_mult
+#(
+   parameter C_MANT_PRENORM = fpu_defs::C_MANT_PRENORM,
+   parameter C_EXP_PRENORM  = fpu_defs::C_EXP_PRENORM,
+   parameter C_EXP          = fpu_defs::C_EXP,
+   parameter C_MANT         = fpu_defs::C_MANT,
+   parameter C_BIAS         = fpu_defs::C_BIAS
+)
   (//Input
    input logic                              Sign_a_DI,
    input logic                              Sign_b_DI,

--- a/hdl/fpu_v0.1/fpu_norm.sv
+++ b/hdl/fpu_v0.1/fpu_norm.sv
@@ -27,6 +27,10 @@
 //                                                                            //
 //                                                                            //
 // Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/hdl/fpu_v0.1/fpu_norm.sv
+++ b/hdl/fpu_v0.1/fpu_norm.sv
@@ -33,6 +33,27 @@
 import fpu_defs::*;
 
 module fpu_norm
+#(
+   parameter C_MANT_PRENORM     = fpu_defs::C_MANT_PRENORM,
+   parameter C_EXP_PRENORM      = fpu_defs::C_EXP_PRENORM,
+   parameter C_MANT_PRENORM_IND = fpu_defs::C_MANT_PRENORM_IND,
+   parameter C_EXP_ZERO         = fpu_defs::C_EXP_ZERO,
+   parameter C_EXP_INF          = fpu_defs::C_EXP_INF,
+
+   parameter C_RM               = fpu_defs::C_RM,
+   parameter C_CMD              = fpu_defs::C_CMD,
+   parameter C_MANT             = fpu_defs::C_MANT,
+   parameter C_EXP              = fpu_defs::C_EXP,
+
+   parameter C_FPU_ADD_CMD      = fpu_defs::C_FPU_ADD_CMD,
+   parameter C_FPU_SUB_CMD      = fpu_defs::C_FPU_SUB_CMD,
+   parameter C_FPU_MUL_CMD      = fpu_defs::C_FPU_MUL_CMD,
+
+   parameter C_RM_NEAREST       = fpu_defs::C_RM_NEAREST,
+   parameter C_RM_TRUNC         = fpu_defs::C_RM_TRUNC,
+   parameter C_RM_PLUSINF       = fpu_defs::C_RM_PLUSINF,
+   parameter C_RM_MINUSINF      = fpu_defs::C_RM_MINUSINF
+)
   (
    //Input Operands
    input logic        [C_MANT_PRENORM-1:0] Mant_in_DI,

--- a/hdl/fpu_v0.1/fpu_norm.sv
+++ b/hdl/fpu_v0.1/fpu_norm.sv
@@ -13,7 +13,7 @@
 // Engineers:      Lukas Mueller -- lukasmue@student.ethz.ch                  //
 //                                                                            //
 // Additional contributions by:                                               //
-//                                                                            //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    06/10/2014                                                 //

--- a/hdl/fpu_v0.1/fpu_private.sv
+++ b/hdl/fpu_v0.1/fpu_private.sv
@@ -34,6 +34,25 @@
 import fpu_defs::*;
 
 module fpu_private
+#(
+   parameter C_OP             = fpu_defs::C_OP,
+   parameter C_RM             = fpu_defs::C_RM,
+   parameter C_CMD            = fpu_defs::C_CMD,
+   parameter C_PC             = fpu_defs::C_PC,
+   parameter C_FFLAG          = fpu_defs::C_FFLAG,
+
+   parameter C_FPU_ADD_CMD    = fpu_defs::C_FPU_ADD_CMD,
+   parameter C_FPU_SUB_CMD    = fpu_defs::C_FPU_SUB_CMD,
+   parameter C_FPU_MUL_CMD    = fpu_defs::C_FPU_MUL_CMD,
+   parameter C_FPU_DIV_CMD    = fpu_defs::C_FPU_DIV_CMD,
+   parameter C_FPU_SQRT_CMD   = fpu_defs::C_FPU_SQRT_CMD,
+   parameter C_FPU_I2F_CMD    = fpu_defs::C_FPU_I2F_CMD,
+   parameter C_FPU_F2I_CMD    = fpu_defs::C_FPU_F2I_CMD,
+   parameter C_FPU_FMADD_CMD  = fpu_defs::C_FPU_FMADD_CMD,
+   parameter C_FPU_FMSUB_CMD  = fpu_defs::C_FPU_FMSUB_CMD,
+   parameter C_FPU_FNMADD_CMD = fpu_defs::C_FPU_FNMADD_CMD,
+   parameter C_FPU_FNMSUB_CMD = fpu_defs::C_FPU_FNMSUB_CMD
+)
   (
    //Clock and reset
    input logic 	              clk_i,

--- a/hdl/fpu_v0.1/fpu_private.sv
+++ b/hdl/fpu_v0.1/fpu_private.sv
@@ -29,6 +29,11 @@
 //                                                                            //
 // Revision:                                                                  //
 //            01/06/2017 added divsqrt module                                 //
+// Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs::*;

--- a/hdl/fpu_v0.1/fpu_private.sv
+++ b/hdl/fpu_v0.1/fpu_private.sv
@@ -12,9 +12,10 @@
 //                                                                            //
 // Engineers:      Lukas Mueller -- lukasmue@student.ethz.ch                  //
 //                 Thomas Gautschi -- gauthoma@student.ethz.ch                //
-//		                                                                        //
+//                                                                            //
 // Additional contributions by:                                               //
 //                 Michael Gautschi -- gautschi@iis.ee.ethz.ch                //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    26/10/2014                                                 //

--- a/hdl/fpu_v0.1/fpu_shared.sv
+++ b/hdl/fpu_v0.1/fpu_shared.sv
@@ -12,8 +12,9 @@
 //                                                                            //
 // Engineers:      Lukas Mueller -- lukasmue@student.ethz.ch                  //
 //                 Thomas Gautschi -- gauthoma@sutdent.ethz.ch                //
-//		                                                                        //
+//                                                                            //
 // Additional contributions by:                                               //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 //                                                                            //

--- a/hdl/fpu_v0.1/fpu_shared.sv
+++ b/hdl/fpu_v0.1/fpu_shared.sv
@@ -32,7 +32,13 @@ import fpu_defs::*;
 
 module fpu_shared
   #(
-    parameter ADD_REGISTER = 1
+    parameter ADD_REGISTER = 1,
+
+    parameter C_OP         = fpu_defs::C_OP,
+    parameter C_CMD        = fpu_defs::C_CMD,
+    parameter C_RM         = fpu_defs::C_RM,
+    parameter C_TAG        = fpu_defs::C_TAG,
+    parameter C_FLAG       = fpu_defs::C_FLAG
     )
   (
    input logic     Clk_CI,

--- a/hdl/fpu_v0.1/fpu_shared.sv
+++ b/hdl/fpu_v0.1/fpu_shared.sv
@@ -26,6 +26,10 @@
 // Description:    Wrapper for connecting the FPU to the shared interconnect  //
 //                                                                            //
 // Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs::*;

--- a/hdl/fpu_v0.1/riscv_fpu.sv
+++ b/hdl/fpu_v0.1/riscv_fpu.sv
@@ -28,6 +28,10 @@
 //                                                                            //
 //                                                                            //
 // Revision:                                                                  //
+//                15/05/2018                                                  //
+//                Pass package parameters as default args instead of using    //
+//                them directly, improves compatibility with tools like       //  
+//                Synopsys Spyglass and DC (GitHub #7) - Torbjørn Viem Ness   //
 ////////////////////////////////////////////////////////////////////////////////
 
 import fpu_defs::*;
@@ -122,7 +126,6 @@ module riscv_fpu
       .Operand_b_DI  ( operand_b_i      ),
       .RM_SI         ( rounding_mode_i  ),
       .OP_SI         ( operator_i       ),
-      .Stall_SI      ( stall_i          ),
 
       .Result_DO     ( result_o         ),
 

--- a/hdl/fpu_v0.1/riscv_fpu.sv
+++ b/hdl/fpu_v0.1/riscv_fpu.sv
@@ -33,6 +33,11 @@
 import fpu_defs::*;
 
 module riscv_fpu
+#(
+   parameter C_OP  = fpu_defs::C_OP,
+   parameter C_RM  = fpu_defs::C_RM,
+   parameter C_CMD = fpu_defs::C_CMD
+)
   (
    //Clock and reset
    input logic             clk,

--- a/hdl/fpu_v0.1/riscv_fpu.sv
+++ b/hdl/fpu_v0.1/riscv_fpu.sv
@@ -14,7 +14,7 @@
 //                 Thomas Gautschi -- gauthoma@student.ethz.ch                //
 //                                                                            //
 // Additional contributions by:                                               //
-//                                                                            //
+//                 Torbjørn Viem Ness -- torbjovn@stud.ntnu.no                //
 //                                                                            //
 //                                                                            //
 // Create Date:    26/10/2014                                                 //


### PR DESCRIPTION
This change introduces the module parameters as positional arguments, initialized with default values from the package.

See issue #6 for more details.

It has been tested and is now confirmed to be working in the following tools:
- Synopsys Spyglass
- Synopsys Design Compiler
- Mentor Graphics QuestaSim
- Sigasi Studio

using the following top level modules:
- fpu_private.sv
- riscv_fpu.sv

Other top level modules have not been tested and and `fpu_shared.sv` is probably a little bit broken (see issue #8), but I leave that to someone who knows the PULP better than myself.
This PR also includes https://github.com/pulp-platform/fpu/pull/7 (as I wasn't clever enough to make a separate branch for that, and needed both fixes for my own development), you can decide what you want to do with it (merge it first or close it)